### PR TITLE
fix(hint): better layout

### DIFF
--- a/lib/components/Hint/index.tsx
+++ b/lib/components/Hint/index.tsx
@@ -28,6 +28,7 @@ interface Props {
         alignItems: 'center',
     },
     tooltip: {
+        marginTop: 5,
         marginLeft: 5,
     },
     hint: {


### PR DESCRIPTION
- center the icon vertically with the text

### BEFORE

![image](https://user-images.githubusercontent.com/16897658/42885723-0a0629f0-8aa2-11e8-8ce5-6df8930d44cf.png)


### AFTER

![image](https://user-images.githubusercontent.com/16897658/42885691-f5d8a8ae-8aa1-11e8-8441-6129ae02b45b.png)


related to https://github.com/getstation/browserX/pull/491