### PR TITLE
Migrate Modal & SliderX Components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
 
+## [0.7.0] - 2018-08-20
+### Added
+- Add ModalWrapper, Modal & SlideX components
+
 ## [0.6.2] - 2018-08-14
 ### Added
 - Add Return Icon

--- a/lib/components/Modal/index.tsx
+++ b/lib/components/Modal/index.tsx
@@ -2,12 +2,12 @@ import classNames from 'classnames';
 import * as React from 'react';
 // @ts-ignore: no declaration file
 import injectSheet from 'react-jss';
-import ModalWrapper from '../ModalWrapper';
+import { ModalWrapper } from '../ModalWrapper';
 import {ThemeTypes} from "../../types";
 import {Icon, IconSymbol} from "../Icon";
 import {Button, Style} from "../Button";
 
-export interface Classes {
+interface Classes {
   container: string,
   header: string,
   applicationIcon: string,
@@ -18,7 +18,7 @@ export interface Classes {
   footer: string,
 }
 
-export interface Props {
+interface Props {
   classes?: Classes,
   classNameModalBody?: string,
   title: string,
@@ -96,7 +96,7 @@ export interface Props {
     },
   },
 }))
-export default class Modal extends React.PureComponent<Props, {}> {
+export class Modal extends React.PureComponent<Props, {}> {
   render() {
     const {
       classes, title, description, classNameModalBody, onCancel, cancelContent, onContinue, continueContent, isLoading, children,

--- a/lib/components/Modal/index.tsx
+++ b/lib/components/Modal/index.tsx
@@ -1,0 +1,143 @@
+import classNames from 'classnames';
+import * as React from 'react';
+// @ts-ignore: no declaration file
+import injectSheet from 'react-jss';
+import ModalWrapper from '../ModalWrapper';
+import {ThemeTypes} from "../../types";
+import {Icon, IconSymbol} from "../Icon";
+import {Button, Style} from "../Button";
+
+export interface Classes {
+  container: string,
+  header: string,
+  applicationIcon: string,
+  body: string,
+  loading: string,
+  title: string,
+  description: string,
+  footer: string,
+}
+
+export interface Props {
+  classes?: Classes,
+  classNameModalBody?: string,
+  title: string,
+  description?: string,
+  onCancel?: () => void,
+  cancelContent?: string,
+  onContinue?: () => void,
+  continueContent?: string,
+  applicationIcon?: string,
+  isLoading?: boolean,
+}
+
+@injectSheet((theme: ThemeTypes) => ({
+  container: {
+    position: 'relative',
+    width: 350,
+    maxHeight: 500,
+    backgroundColor: theme.$bodyBkg,
+    borderRadius: 5,
+  },
+  header: {
+    width: '100%',
+    padding: ({ applicationIcon }: Props) => applicationIcon ? '70px 20px 20px' : 20,
+    textAlign: 'center',
+    backgroundColor: theme.colors.gray.light,
+    boxSizing: 'border-box',
+    borderRadius: [5, 5, 0, 0],
+  },
+  applicationIcon: {
+    display: ({ applicationIcon }: Props) => applicationIcon ? 'initial' : 'none',
+    position: 'absolute',
+    top: -45,
+    left: 'calc(50% - 45px)',
+    width: 90,
+    height: 90,
+    backgroundImage: ({ applicationIcon }: Props) => `url('${applicationIcon}')`,
+    backgroundColor: theme.colors.gray.light,
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: '100%',
+    backgroundPosition: 'center',
+    borderRadius: '100%',
+    border: '3px solid white',
+  },
+  title: {
+    ...theme.fontMixin(18, 500),
+    marginBottom: 5,
+  },
+  description: {
+    ...theme.fontMixin(13),
+    color: '#292929',
+    opacity: .4,
+  },
+  body: {
+    position: 'relative',
+    padding: 20,
+  },
+  '@keyframes spin': {
+    '100%': { transform: 'rotate(360deg)' },
+  },
+  loading: {
+    ...theme.mixins.flexbox.containerCenter,
+    ...theme.mixins.position('absolute', 0, 0),
+    ...theme.mixins.size('100%'),
+    backgroundColor: 'rgba(255, 255, 255, 1)',
+    '& svg': {
+      animation: `spin 1s linear infinite`,
+    },
+  },
+  footer: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: 20,
+    '& button': {
+      flexBasis: ({ onContinue }: Props) => onContinue ? '48%' : '100%',
+    },
+  },
+}))
+export default class Modal extends React.PureComponent<Props, {}> {
+  render() {
+    const {
+      classes, title, description, classNameModalBody, onCancel, cancelContent, onContinue, continueContent, isLoading, children,
+    } = this.props;
+
+    return (
+      <ModalWrapper onCancel={onCancel}>
+        <div className={classes!.container}>
+          <div className={classes!.header}>
+            <div className={classes!.applicationIcon} />
+            <div className={classes!.title}>{title}</div>
+            <div className={classes!.description}>{description}</div>
+          </div>
+
+          <div className={classNames(classes!.body, classNameModalBody)}>
+            { isLoading &&
+            <div className={classes!.loading}>
+              <Icon symbolId={IconSymbol.LOADING} size={25} color={'#000'} />
+            </div>
+            }
+
+            {children}
+          </div>
+
+          { (onCancel || onContinue) &&
+          <div className={classes!.footer}>
+            { onCancel &&
+            <Button onClick={onCancel} btnStyle={Style.TERTIARY}>
+              {cancelContent || `Cancel`}
+            </Button>
+            }
+
+            { onContinue &&
+            <Button onClick={onContinue}>
+              {continueContent || `OK`}
+            </Button>
+            }
+          </div>
+          }
+        </div>
+      </ModalWrapper>
+    );
+  }
+}

--- a/lib/components/Modal/stories.tsx
+++ b/lib/components/Modal/stories.tsx
@@ -2,7 +2,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
-import Modal from './index';
+import { Modal } from './index';
 
 storiesOf('Molecules|Modal', module)
   .addDecorator(withKnobs)

--- a/lib/components/Modal/stories.tsx
+++ b/lib/components/Modal/stories.tsx
@@ -1,0 +1,50 @@
+import { action } from '@storybook/addon-actions';
+import { boolean, text, withKnobs } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import Modal from './index';
+
+storiesOf('Molecules|Modal', module)
+  .addDecorator(withKnobs)
+  .add('Modal', () => (
+    <Modal
+      title={text('Title', 'My modal')}
+      description={text('Description', 'My awesome modal here')}
+      onCancel={action('cancel')}
+    >
+      {text('Content', 'Content of the modal')}
+    </Modal>
+  ))
+  .add('Modal with buttons', () => (
+    <Modal
+      title={text('Title', 'My modal')}
+      description={text('Description', 'My awesome modal here')}
+      onCancel={action('cancel')}
+      onContinue={action('continue')}
+    >
+      {text('Content', 'Content of the modal with action buttons')}
+    </Modal>
+  ))
+  .add('Modal with buttons and App icon', () => (
+    <Modal
+      title={text('Title', 'My modal')}
+      description={text('Description', 'My awesome modal here')}
+      onCancel={action('cancel')}
+      onContinue={action('continue')}
+      applicationIcon={text('applicationIcon', 'https://pbs.twimg.com/profile_images/959451316903845889/BpKfHFc4_400x400.jpg')}
+    >
+      {text('Content', 'Content of the modal with buttons and Application icon')}
+    </Modal>
+  ))
+  .add('Modal - loading state', () => (
+    <Modal
+      title={text('Title', 'My modal')}
+      description={text('Description', 'My awesome modal here')}
+      onCancel={action('cancel')}
+      onContinue={action('continue')}
+      applicationIcon={text('applicationIcon', 'https://pbs.twimg.com/profile_images/959451316903845889/BpKfHFc4_400x400.jpg')}
+      isLoading={boolean('isLoading', true)}
+    >
+      {text('Content', 'Content of the modal with buttons and Application icon')}
+    </Modal>
+  ));

--- a/lib/components/ModalWrapper/index.tsx
+++ b/lib/components/ModalWrapper/index.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+// @ts-ignore: no declaration file
+import injectSheet from 'react-jss';
+// @ts-ignore: no declaration file
+import KeyHandler, { KEYDOWN } from 'react-key-handler';
+import { ThemeTypes } from "../../types";
+
+interface Classes {
+  container: string,
+}
+
+export interface StateToProps {
+  classes?: Classes,
+}
+
+interface OwnProps {
+  onCancel?: (e: React.SyntheticEvent<HTMLElement>) => void,
+  children: React.ReactElement<any>,
+  backgroundOverlay?: boolean,
+}
+
+type Props = StateToProps & OwnProps;
+
+@injectSheet((theme: ThemeTypes) => ({
+  container: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    ...theme.mixins.flexbox.containerCenter,
+    backgroundColor: (props: Props) => props.backgroundOverlay ? 'rgba(0, 0, 0, .3)' : 'none',
+    zIndex: theme.$zIndexSupra,
+  },
+}))
+export default class ModalWrapper extends React.PureComponent<Props, {}> {
+  public static defaultProps = {
+    backgroundOverlay: true,
+    onCancel: () => {},
+  };
+
+  modalWrapper!: HTMLDivElement | null;
+
+  constructor(props: Props) {
+    super(props);
+
+    this.handleClickOutside = this.handleClickOutside.bind(this);
+    this.setModalWrapperRef = this.setModalWrapperRef.bind(this);
+  }
+
+  /**
+   using Portal kinda disturbs ClickOutside.
+   let's do some logic here to check that the click outside
+   is definitely outside ModalWrapper before calling hide
+   **/
+  handleClickOutside(e: React.SyntheticEvent<HTMLElement>) {
+    if (!this.modalWrapper) return;
+    const target = e.target as HTMLElement;
+    if (e.currentTarget === target) this.props.onCancel!(e);
+  }
+
+  setModalWrapperRef(modalWrapper: HTMLDivElement | null) {
+    this.modalWrapper = modalWrapper;
+  }
+
+  render() {
+    const { classes, onCancel, children } = this.props;
+
+    return (
+      <div className={classes!.container} ref={this.setModalWrapperRef} onClick={this.handleClickOutside}>
+        { onCancel &&
+        <KeyHandler
+          keyEventName={KEYDOWN}
+          keyValue="Escape"
+          onKeyHandle={onCancel}
+        />
+        }
+
+        {children}
+      </div>
+    );
+  }
+}

--- a/lib/components/ModalWrapper/index.tsx
+++ b/lib/components/ModalWrapper/index.tsx
@@ -9,7 +9,7 @@ interface Classes {
   container: string,
 }
 
-export interface StateToProps {
+interface StateToProps {
   classes?: Classes,
 }
 
@@ -33,7 +33,7 @@ type Props = StateToProps & OwnProps;
     zIndex: theme.$zIndexSupra,
   },
 }))
-export default class ModalWrapper extends React.PureComponent<Props, {}> {
+export class ModalWrapper extends React.PureComponent<Props, {}> {
   public static defaultProps = {
     backgroundOverlay: true,
     onCancel: () => {},

--- a/lib/components/ModalWrapper/stories.tsx
+++ b/lib/components/ModalWrapper/stories.tsx
@@ -1,0 +1,19 @@
+import { boolean, withKnobs } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { ModalWrapper } from "./index";
+
+const containerStyle = {
+  padding: 40,
+  backgroundColor: 'white',
+  borderRadius: 8,
+  border: '1px solid',
+};
+
+storiesOf('Molecules|Modal Wrapper', module)
+  .addDecorator(withKnobs)
+  .add('Modal Wrapper', () => (
+    <ModalWrapper backgroundOverlay={boolean('backgroundOverlay', true)}>
+      <div style={containerStyle}>Modal Wrapper</div>
+    </ModalWrapper>
+  ));

--- a/lib/components/SlideX/index.tsx
+++ b/lib/components/SlideX/index.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+// @ts-ignore: no declaration file
+import injectSheet from 'react-jss';
+
+export interface Classes {
+  stepAnimationContainer: string,
+  stepAnimation: string,
+}
+
+export interface Props {
+  classes?: Classes,
+  step: number,
+}
+
+const styles = {
+  stepAnimationContainer: {
+    overflowX: 'hidden',
+    width: '100%',
+  },
+  stepAnimation: {
+    transition: 'transform .6s',
+    display: 'flex',
+    alignItems: 'flex-end',
+    justifyContent: 'flex-start',
+    width: '100%',
+    transform: ({ step }: Props) => step ? `translateX(-${step * 100}%)` : 'translateX(0)',
+
+    '& > *': {
+      minWidth: '100%',
+    },
+  },
+};
+
+@injectSheet(styles)
+export default class SlideX extends React.PureComponent<Props, {}> {
+
+  static defaultProps = {
+    step: 0,
+  };
+
+  render() {
+    const { classes, children } = this.props;
+
+    return (
+      <div className={classes!.stepAnimationContainer}>
+        <div className={classes!.stepAnimation}>
+          {children}
+        </div>
+      </div>
+    );
+  }
+}

--- a/lib/components/SlideX/index.tsx
+++ b/lib/components/SlideX/index.tsx
@@ -2,17 +2,17 @@ import * as React from 'react';
 // @ts-ignore: no declaration file
 import injectSheet from 'react-jss';
 
-export interface Classes {
+interface Classes {
   stepAnimationContainer: string,
   stepAnimation: string,
 }
 
-export interface Props {
+interface Props {
   classes?: Classes,
   step: number,
 }
 
-const styles = {
+@injectSheet({
   stepAnimationContainer: {
     overflowX: 'hidden',
     width: '100%',
@@ -29,10 +29,8 @@ const styles = {
       minWidth: '100%',
     },
   },
-};
-
-@injectSheet(styles)
-export default class SlideX extends React.PureComponent<Props, {}> {
+})
+export class SlideX extends React.PureComponent<Props, {}> {
 
   static defaultProps = {
     step: 0,

--- a/lib/components/SlideX/stories.tsx
+++ b/lib/components/SlideX/stories.tsx
@@ -1,0 +1,24 @@
+import {number, withKnobs} from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
+import centered from "@storybook/addon-centered";
+import * as React from 'react';
+import SlideX from './index';
+
+const containerStyle = {
+  padding: 40,
+  'box-sizing': 'border-box',
+  backgroundColor: 'white',
+  borderRadius: 8,
+  border: '1px solid',
+};
+
+storiesOf('Molecules|SlideX', module)
+  .addDecorator(withKnobs)
+  .addDecorator(centered)
+  .add('Slides', () => (
+    <SlideX step={number('step', 0)}>
+      <div style={containerStyle}>First Step</div>
+      <div style={containerStyle}>Second Step</div>
+      <div style={containerStyle}>Third Step</div>
+    </SlideX>
+  ));

--- a/lib/components/SlideX/stories.tsx
+++ b/lib/components/SlideX/stories.tsx
@@ -2,7 +2,7 @@ import {number, withKnobs} from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import centered from "@storybook/addon-centered";
 import * as React from 'react';
-import SlideX from './index';
+import { SlideX } from './index';
 
 const containerStyle = {
   padding: 40,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,3 +13,6 @@ export * from './components/Input';
 export * from './components/ChooserItem';
 export * from './components/Chooser';
 export * from './components/ButtonFeedback';
+export * from './components/ModalWrapper';
+export * from './components/Modal';
+export * from './components/SlideX';

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-dom": "^16.3.1",
     "react-hover-observer": "^2.1.0",
     "react-jss": "^8.4.0",
-    "react-key-handler": "^1.1.0",
+    "react-key-handler": "1.0.1",
     "react-popper": "^0.10.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getstation/theme",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Station Theme & Styleguide",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^16.3.1",
     "react-hover-observer": "^2.1.0",
     "react-jss": "^8.4.0",
+    "react-key-handler": "^1.1.0",
     "react-popper": "^0.10.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5201,13 +5201,6 @@ prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8,
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
-  dependencies:
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 property-information@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-4.1.0.tgz#16f817d8c087f3018b91877c193d730570487bb2"
@@ -5466,12 +5459,12 @@ react-jss@^8.4.0:
     prop-types "^15.6.0"
     theming "^1.3.0"
 
-react-key-handler@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-key-handler/-/react-key-handler-1.1.0.tgz#c4e74ce35567cea55fa8e6d35ba7dadd79dd31ab"
+react-key-handler@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/react-key-handler/-/react-key-handler-1.0.1.tgz#1fc0f4f4855f506a192c2cbe9fe8cb78fc553191"
   dependencies:
     exenv "^1.2.0"
-    prop-types "^15.6.2"
+    prop-types "^15.5.7"
 
 react-lifecycles-compat@^3.0.0:
   version "3.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5201,6 +5201,13 @@ prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8,
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 property-information@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-4.1.0.tgz#16f817d8c087f3018b91877c193d730570487bb2"
@@ -5458,6 +5465,13 @@ react-jss@^8.4.0:
     jss-preset-default "^4.3.0"
     prop-types "^15.6.0"
     theming "^1.3.0"
+
+react-key-handler@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-key-handler/-/react-key-handler-1.1.0.tgz#c4e74ce35567cea55fa8e6d35ba7dadd79dd31ab"
+  dependencies:
+    exenv "^1.2.0"
+    prop-types "^15.6.2"
 
 react-lifecycles-compat@^3.0.0:
   version "3.0.4"


### PR DESCRIPTION
## What is this PR

Move the following components to Theme:

- `<ModalWrapper />`
- `<Modal />`
- `<SliderX />`

`react-key-handler@1.1.0` is broken (see https://github.com/ayrton/react-key-handler/issues/149). Package version is locked to `1.0.1` until `1.2.0` is released.

## Todo
- [x] Bump version & Tag & Publish
- [x] Changelog