### PR TITLE
Add `disableWrapperClick` prop to Modal component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
+## Changed
+- Add `disableWrapperClick` props to `Modal` component
+
 ## [0.9.5] - 2019-03-19
 ## Changed
 - Add `themeColor` props to `Modal` component

--- a/lib/components/Modal/index.tsx
+++ b/lib/components/Modal/index.tsx
@@ -11,6 +11,7 @@ interface OwnProps {
   title?: string,
   description?: string,
   onCancel?: () => void,
+  onWrapperCancel?: () => void,
   cancelContent?: string,
   onContinue?: () => void,
   continueContent?: string,
@@ -18,6 +19,7 @@ interface OwnProps {
   applicationIcon?: string,
   themeColor?: string,
   isLoading?: boolean,
+  disableWrapperClick?: boolean,
 }
 
 const styles = (theme: ThemeTypes) => createStyles({
@@ -104,11 +106,11 @@ class ModalImpl extends React.PureComponent<Props, {}> {
   render() {
     const {
       classes, title, description, classNameModalBody, onCancel, cancelContent, onContinue, continueContent,
-      isLoading, children, continueDanger,
+      isLoading, children, continueDanger, disableWrapperClick,
     } = this.props;
 
     return (
-      <ModalWrapper onCancel={onCancel}>
+      <ModalWrapper onCancel={(disableWrapperClick) ? undefined : onCancel}>
         <div className={classes.container}>
           <div className={classes.header}>
             <div className={classes.applicationIcon} />

--- a/lib/components/Modal/index.tsx
+++ b/lib/components/Modal/index.tsx
@@ -25,7 +25,7 @@ interface OwnProps {
 const styles = (theme: ThemeTypes) => createStyles({
   container: {
     position: 'relative',
-    width: 450,
+    width: 400,
     maxHeight: 500,
     backgroundColor: theme.$bodyBkg,
     borderRadius: 5,

--- a/lib/components/Modal/index.tsx
+++ b/lib/components/Modal/index.tsx
@@ -106,11 +106,11 @@ class ModalImpl extends React.PureComponent<Props, {}> {
   render() {
     const {
       classes, title, description, classNameModalBody, onCancel, cancelContent, onContinue, continueContent,
-      isLoading, children, continueDanger, disableWrapperClick,
+      isLoading, children, continueDanger, onWrapperCancel, disableWrapperClick,
     } = this.props;
 
     return (
-      <ModalWrapper onCancel={(disableWrapperClick) ? undefined : onCancel}>
+      <ModalWrapper onCancel={(disableWrapperClick) ? undefined : (onWrapperCancel || onCancel)}>
         <div className={classes.container}>
           <div className={classes.header}>
             <div className={classes.applicationIcon} />

--- a/lib/components/ModalWrapper/index.tsx
+++ b/lib/components/ModalWrapper/index.tsx
@@ -46,8 +46,9 @@ class ModalWrapperImpl extends React.PureComponent<Props, {}> {
    **/
   handleClickOutside(e: React.SyntheticEvent<HTMLElement>) {
     if (!this.modalWrapper) return;
+
     const target = e.target as HTMLElement;
-    if (e.currentTarget === target) this.props.onCancel!(e);
+    if (e.currentTarget === target && this.props.onCancel) this.props.onCancel(e);
   }
 
   setModalWrapperRef(modalWrapper: HTMLDivElement | null) {


### PR DESCRIPTION
## What is this PR?
This PR adds a new prop to the Modal, needed to control the behavior of the background overlay, related to the App Store and Custom App Live support. See [here](https://www.notion.so/stationhq/SPEC-044-Add-a-custom-app-live-new-behavior-02737d297d574df38d24b99ee55f5095) and [here](https://www.notion.so/stationhq/QA-Reviews-a2c0f43ec609485e942c2018fd988a96) for more details.

## How does it work?
Adds two new props:
- `disableWrapperClick`: When set to `true` it doesn't bind the `onCancel` callback to the overlay wrapper click.
- `onWrapperCancel`: works like `onCancel`, is bound to the click overlay if it exists. If undefined, `onCancel` is used as a fallback.

## Tests
Check the behavior in the AppStore: it has been applied when requesting a new app.
Or set `disableWrapperClick` to true in one modal (in your code) and check that the click on the overlay doesn't react anymore.

## TODO
- [ ] Update changelog