### PR TITLE
New Design Workspace

### DIFF
--- a/lib/components/Modal/index.tsx
+++ b/lib/components/Modal/index.tsx
@@ -26,7 +26,7 @@ const styles = (theme: ThemeTypes) => createStyles({
   container: {
     position: 'relative',
     width: 400,
-    maxHeight: 500,
+    maxHeight: 550,
     backgroundColor: theme.$bodyBkg,
     borderRadius: 5,
   },

--- a/lib/components/Modal/stories.tsx
+++ b/lib/components/Modal/stories.tsx
@@ -32,7 +32,7 @@ storiesOf('Molecules|Modal', module)
       )}
       onCancel={action('cancel')}
     >
-      {text('Content', `Content of the modal: ${loremIpsum}`)}
+      {text('Content', `Content of the modal: ${loremIpsum}. ${loremIpsum}`)}
     </Modal>
   ))
   .add('Modal with buttons', () => (


### PR DESCRIPTION
This PR follows https://github.com/getstation/browserX/pull/846

some elements have been duplicated on browserX instead of using the Theme:
- Scroll into the modal content for the Workspaces edition modal
- The subdock button icon is custom-made and not from the Theme. Should probably leverage the current ButtonIcon component
- Subdock elements are duplicated
- Custom button for the delete workspace action

Should we add all this now to the Theme? It will be also easier if the Theme was merged back to browserX to work on the Design System.

I know all this is not blocking and part of the Design System work. I started this thread to not forget about it.