### PR TITLE
Add withBrowserXTheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+## [0.19.0] - 2019-11-17
+- Added `withBrowserXTheme`
 
+## [0.18.0] - 2019-11-17
 ### Added 
 - Add an `onClickOutside` event listener on modal, default is cancelation.
 - Added prop `iconPosition` for `buttonIcon`, can be *Left* (default) or *Right*

--- a/lib/BrowserXThemeProvider.tsx
+++ b/lib/BrowserXThemeProvider.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { ThemeProvider, jss } from 'react-jss';
+import { ThemeProvider, jss, withTheme } from 'react-jss';
 // @ts-ignore: no typing declaration for 'jss-nested'
 import jssNested from 'jss-nested';
 import { theme } from './jss';
+import { ThemeTypes } from './types';
 
 export interface BrowserXThemeProviderProps {
   children: any,
@@ -22,3 +23,15 @@ export class BrowserXThemeProvider extends React.Component<BrowserXThemeProvider
     );
   }
 }
+
+/**
+ * Returns a component with an already passed `theme` with
+ * current BrowserXTheme.
+ */
+export function withBrowserXTheme<P>(
+  component: React.ComponentType<P & { theme: ThemeTypes }>
+): React.ComponentType<Pick<P, Exclude<keyof P, "theme">>> {
+  // @ts-ignore ?
+  return withTheme(component);
+};
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getstation/theme",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Station Theme & Styleguide",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Added `withBrowserXTheme` with is an equivalent `react-jss`'s `withTheme`.